### PR TITLE
修正 myDS.h中category的命名衝突

### DIFF
--- a/myDS.h
+++ b/myDS.h
@@ -12,9 +12,9 @@ struct inventory {
     struct inventory *next;
 };
 
-struct categoty {
+struct category {
     enum bookType type;
-    struct Inventory *Inventory_head;
+    struct Inventory *inv_head;
 };
 
 /****************************************


### PR DESCRIPTION
struct category {
    enum bookType type;
    struct Inventory *inv_head;
};